### PR TITLE
treewide: introduce formatter

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,8 @@
+# You can set this file as a default ignore file for blame by running
+# the following command.
+#
+# $ git config blame.ignoreRevsFile .git-blame-ignore-revs
+#
+
+# treewide: re-format
+69532003a7d4b95c0fc508c6ee777411a9b3dd3b

--- a/apple-silicon-support/modules/boot-m1n1/default.nix
+++ b/apple-silicon-support/modules/boot-m1n1/default.nix
@@ -1,4 +1,9 @@
-{ config, pkgs, lib, ... }:
+{
+  config,
+  pkgs,
+  lib,
+  ...
+}:
 let
   pkgs' = config.hardware.asahi.pkgs;
 
@@ -13,7 +18,7 @@ let
   };
 
   bootFiles = {
-    "m1n1/boot.bin" = pkgs.runCommand "boot.bin" {} ''
+    "m1n1/boot.bin" = pkgs.runCommand "boot.bin" { } ''
       cat ${bootM1n1}/build/m1n1.bin > $out
       cat ${config.boot.kernelPackages.kernel}/dtbs/apple/*.dtb >> $out
       cat ${bootUBoot}/u-boot-nodtb.bin.gz >> $out
@@ -22,14 +27,18 @@ let
       fi
     '';
   };
-in {
+in
+{
   config = lib.mkIf config.hardware.asahi.enable {
     # install m1n1 with the boot loader
     boot.loader.grub.extraFiles = bootFiles;
     boot.loader.systemd-boot.extraFiles = bootFiles;
 
     # ensure the installer has m1n1 in the image
-    system.extraDependencies = lib.mkForce [ bootM1n1 bootUBoot ];
+    system.extraDependencies = lib.mkForce [
+      bootM1n1
+      bootUBoot
+    ];
     system.build.m1n1 = bootFiles."m1n1/boot.bin";
   };
 

--- a/apple-silicon-support/modules/default.nix
+++ b/apple-silicon-support/modules/default.nix
@@ -1,4 +1,9 @@
-{ config, pkgs, lib, ... }:
+{
+  config,
+  pkgs,
+  lib,
+  ...
+}:
 {
   imports = [
     ./kernel
@@ -8,20 +13,22 @@
     ./sound
   ];
 
-  config = let
+  config =
+    let
       cfg = config.hardware.asahi;
-    in lib.mkIf cfg.enable {
+    in
+    lib.mkIf cfg.enable {
       nixpkgs.overlays = lib.mkBefore [ cfg.overlay ];
 
       hardware.asahi.pkgs =
-        if cfg.pkgsSystem != "aarch64-linux"
-        then
+        if cfg.pkgsSystem != "aarch64-linux" then
           import (pkgs.path) {
             crossSystem.system = "aarch64-linux";
             localSystem.system = cfg.pkgsSystem;
             overlays = [ cfg.overlay ];
           }
-        else pkgs;
+        else
+          pkgs;
     };
 
   options.hardware.asahi = {

--- a/apple-silicon-support/modules/kernel/default.nix
+++ b/apple-silicon-support/modules/kernel/default.nix
@@ -1,11 +1,17 @@
 # the Asahi Linux kernel and options that must go along with it
 
-{ config, pkgs, lib, ... }:
+{
+  config,
+  pkgs,
+  lib,
+  ...
+}:
 {
   config = lib.mkIf config.hardware.asahi.enable {
-    boot.kernelPackages = let
-      pkgs' = config.hardware.asahi.pkgs;
-    in
+    boot.kernelPackages =
+      let
+        pkgs' = config.hardware.asahi.pkgs;
+      in
       pkgs'.linux-asahi.override {
         _kernelPatches = config.boot.kernelPatches;
       };
@@ -91,9 +97,11 @@
   };
 
   imports = [
-    (lib.mkRemovedOptionModule [ "hardware" "asahi" "addEdgeKernelConfig" ]
-      "All edge kernel config options are now the default.")
-    (lib.mkRemovedOptionModule [ "hardware" "asahi" "withRust" ]
-      "Rust support is now the default.")
+    (lib.mkRemovedOptionModule [
+      "hardware"
+      "asahi"
+      "addEdgeKernelConfig"
+    ] "All edge kernel config options are now the default.")
+    (lib.mkRemovedOptionModule [ "hardware" "asahi" "withRust" ] "Rust support is now the default.")
   ];
 }

--- a/apple-silicon-support/modules/mesa/default.nix
+++ b/apple-silicon-support/modules/mesa/default.nix
@@ -1,22 +1,24 @@
 { config, lib, ... }:
 {
-  config = lib.mkIf config.hardware.asahi.enable (lib.mkMerge [
-    {
-      # required for proper DRM setup even without GPU driver
-      services.xserver.config = ''
-        Section "OutputClass"
-            Identifier "appledrm"
-            MatchDriver "apple"
-            Driver "modesetting"
-            Option "PrimaryGPU" "true"
-        EndSection
-      '';
-    }
-    (lib.mkIf config.hardware.asahi.useExperimentalGPUDriver {
-      # install the Asahi Mesa version
-      hardware.graphics.package = config.hardware.asahi.pkgs.mesa-asahi-edge;
-    })
-  ]);
+  config = lib.mkIf config.hardware.asahi.enable (
+    lib.mkMerge [
+      {
+        # required for proper DRM setup even without GPU driver
+        services.xserver.config = ''
+          Section "OutputClass"
+              Identifier "appledrm"
+              MatchDriver "apple"
+              Driver "modesetting"
+              Option "PrimaryGPU" "true"
+          EndSection
+        '';
+      }
+      (lib.mkIf config.hardware.asahi.useExperimentalGPUDriver {
+        # install the Asahi Mesa version
+        hardware.graphics.package = config.hardware.asahi.pkgs.mesa-asahi-edge;
+      })
+    ]
+  );
 
   options.hardware.asahi.useExperimentalGPUDriver = lib.mkOption {
     type = lib.types.bool;
@@ -30,7 +32,11 @@
 
   # hopefully no longer used, should be deprecated eventually
   options.hardware.asahi.experimentalGPUInstallMode = lib.mkOption {
-    type = lib.types.enum [ "driver" "replace" "overlay" ];
+    type = lib.types.enum [
+      "driver"
+      "replace"
+      "overlay"
+    ];
     default = "replace";
     description = ''
       Mode to use to install the experimental GPU driver into the system.

--- a/apple-silicon-support/modules/peripheral-firmware/default.nix
+++ b/apple-silicon-support/modules/peripheral-firmware/default.nix
@@ -1,8 +1,14 @@
-{ config, pkgs, lib, ... }:
+{
+  config,
+  pkgs,
+  lib,
+  ...
+}:
 {
   config = lib.mkIf config.hardware.asahi.enable {
     assertions = lib.mkIf config.hardware.asahi.extractPeripheralFirmware [
-      { assertion = config.hardware.asahi.peripheralFirmwareDirectory != null;
+      {
+        assertion = config.hardware.asahi.peripheralFirmwareDirectory != null;
         message = ''
           Asahi peripheral firmware extraction is enabled but the firmware
           location appears incorrect.
@@ -10,26 +16,34 @@
       }
     ];
 
-    hardware.firmware = let
-      pkgs' = config.hardware.asahi.pkgs;
-    in
-      lib.mkIf ((config.hardware.asahi.peripheralFirmwareDirectory != null)
-          && config.hardware.asahi.extractPeripheralFirmware) [
-        (pkgs.stdenv.mkDerivation {
-          name = "asahi-peripheral-firmware";
+    hardware.firmware =
+      let
+        pkgs' = config.hardware.asahi.pkgs;
+      in
+      lib.mkIf
+        (
+          (config.hardware.asahi.peripheralFirmwareDirectory != null)
+          && config.hardware.asahi.extractPeripheralFirmware
+        )
+        [
+          (pkgs.stdenv.mkDerivation {
+            name = "asahi-peripheral-firmware";
 
-          nativeBuildInputs = [ pkgs'.asahi-fwextract pkgs.cpio ];
+            nativeBuildInputs = [
+              pkgs'.asahi-fwextract
+              pkgs.cpio
+            ];
 
-          buildCommand = ''
-            mkdir extracted
-            asahi-fwextract ${config.hardware.asahi.peripheralFirmwareDirectory} extracted
+            buildCommand = ''
+              mkdir extracted
+              asahi-fwextract ${config.hardware.asahi.peripheralFirmwareDirectory} extracted
 
-            mkdir -p $out/lib/firmware
-            cat extracted/firmware.cpio | cpio -id --quiet --no-absolute-filenames
-            mv vendorfw/* $out/lib/firmware
-          '';
-        })
-      ];
+              mkdir -p $out/lib/firmware
+              cat extracted/firmware.cpio | cpio -id --quiet --no-absolute-filenames
+              mv vendorfw/* $out/lib/firmware
+            '';
+          })
+        ];
   };
 
   options.hardware.asahi = {
@@ -45,13 +59,12 @@
     peripheralFirmwareDirectory = lib.mkOption {
       type = lib.types.nullOr lib.types.path;
 
-      default = lib.findFirst (path: builtins.pathExists (path + "/all_firmware.tar.gz")) null
-        [
-          # path when the system is operating normally
-          /boot/asahi
-          # path when the system is mounted in the installer
-          /mnt/boot/asahi
-        ];
+      default = lib.findFirst (path: builtins.pathExists (path + "/all_firmware.tar.gz")) null [
+        # path when the system is operating normally
+        /boot/asahi
+        # path when the system is mounted in the installer
+        /mnt/boot/asahi
+      ];
 
       description = ''
         Path to the directory containing the non-free non-redistributable

--- a/apple-silicon-support/modules/sound/default.nix
+++ b/apple-silicon-support/modules/sound/default.nix
@@ -1,4 +1,10 @@
-{ config, options, pkgs, lib, ... }:
+{
+  config,
+  options,
+  pkgs,
+  lib,
+  ...
+}:
 
 {
   options.hardware.asahi = {
@@ -12,38 +18,44 @@
     };
   };
 
-  config = let
-    cfg = config.hardware.asahi;
-  in lib.mkIf (cfg.setupAsahiSound && cfg.enable) (lib.mkMerge [
-    {
-      # can't be used by Asahi sound infrastructure
-      services.pulseaudio.enable = false;
-      # enable pipewire to run real-time and avoid audible glitches
-      security.rtkit.enable = true;
-      # set up pipewire with the supported capabilities (instead of pulseaudio)
-      # and asahi-audio configs and plugins
-      services.pipewire = {
-        enable = true;
-        alsa.enable = true;
-        pulse.enable = true;
+  config =
+    let
+      cfg = config.hardware.asahi;
+    in
+    lib.mkIf (cfg.setupAsahiSound && cfg.enable) (
+      lib.mkMerge [
+        {
+          # can't be used by Asahi sound infrastructure
+          services.pulseaudio.enable = false;
+          # enable pipewire to run real-time and avoid audible glitches
+          security.rtkit.enable = true;
+          # set up pipewire with the supported capabilities (instead of pulseaudio)
+          # and asahi-audio configs and plugins
+          services.pipewire = {
+            enable = true;
+            alsa.enable = true;
+            pulse.enable = true;
 
-        configPackages = [ pkgs.asahi-audio ];
+            configPackages = [ pkgs.asahi-audio ];
 
-        wireplumber = {
-          enable = true;
+            wireplumber = {
+              enable = true;
 
-          configPackages = [ pkgs.asahi-audio ];
-        };
-      };
+              configPackages = [ pkgs.asahi-audio ];
+            };
+          };
 
-      # set up enivronment so that UCM configs are used as well
-      environment.variables.ALSA_CONFIG_UCM2 = "${pkgs.alsa-ucm-conf-asahi}/share/alsa/ucm2";
-      systemd.user.services.pipewire.environment.ALSA_CONFIG_UCM2 = config.environment.variables.ALSA_CONFIG_UCM2;
-      systemd.user.services.wireplumber.environment.ALSA_CONFIG_UCM2 = config.environment.variables.ALSA_CONFIG_UCM2;
+          # set up enivronment so that UCM configs are used as well
+          environment.variables.ALSA_CONFIG_UCM2 = "${pkgs.alsa-ucm-conf-asahi}/share/alsa/ucm2";
+          systemd.user.services.pipewire.environment.ALSA_CONFIG_UCM2 =
+            config.environment.variables.ALSA_CONFIG_UCM2;
+          systemd.user.services.wireplumber.environment.ALSA_CONFIG_UCM2 =
+            config.environment.variables.ALSA_CONFIG_UCM2;
 
-      # enable speakersafetyd to protect speakers
-      systemd.packages = [ pkgs.speakersafetyd ];
-      services.udev.packages = [ pkgs.speakersafetyd ];
-    }
-  ]);
+          # enable speakersafetyd to protect speakers
+          systemd.packages = [ pkgs.speakersafetyd ];
+          services.udev.packages = [ pkgs.speakersafetyd ];
+        }
+      ]
+    );
 }

--- a/apple-silicon-support/packages/alsa-ucm-conf-asahi/default.nix
+++ b/apple-silicon-support/packages/alsa-ucm-conf-asahi/default.nix
@@ -1,22 +1,29 @@
-{ lib
-, fetchFromGitHub
-, alsa-ucm-conf
+{
+  lib,
+  fetchFromGitHub,
+  alsa-ucm-conf,
 }:
 
-(alsa-ucm-conf.overrideAttrs (oldAttrs: let
-  versionAsahi = "8";
+(alsa-ucm-conf.overrideAttrs (
+  oldAttrs:
+  let
+    versionAsahi = "8";
 
-  srcAsahi = fetchFromGitHub {
-    # tracking: https://src.fedoraproject.org/rpms/alsa-ucm-asahi
-    owner = "AsahiLinux";
-    repo = "alsa-ucm-conf-asahi";
-    rev = "v${versionAsahi}";
-    hash = "sha256-FPrAzscc1ICSCQSqULaGLqG4UCq8GZU9XLV7TUSBBRM=";
-  };
-in {
-  name = "${oldAttrs.pname}-${oldAttrs.version}-asahi-${versionAsahi}";
+    srcAsahi = fetchFromGitHub {
+      # tracking: https://src.fedoraproject.org/rpms/alsa-ucm-asahi
+      owner = "AsahiLinux";
+      repo = "alsa-ucm-conf-asahi";
+      rev = "v${versionAsahi}";
+      hash = "sha256-FPrAzscc1ICSCQSqULaGLqG4UCq8GZU9XLV7TUSBBRM=";
+    };
+  in
+  {
+    name = "${oldAttrs.pname}-${oldAttrs.version}-asahi-${versionAsahi}";
 
-  postInstall = oldAttrs.postInstall or "" + ''
-    cp -r ${srcAsahi}/ucm2 $out/share/alsa
-  '';
-}))
+    postInstall =
+      oldAttrs.postInstall or ""
+      + ''
+        cp -r ${srcAsahi}/ucm2 $out/share/alsa
+      '';
+  }
+))

--- a/apple-silicon-support/packages/asahi-audio/default.nix
+++ b/apple-silicon-support/packages/asahi-audio/default.nix
@@ -1,9 +1,10 @@
-{ stdenv
-, lib
-, fetchFromGitHub
-, lsp-plugins
-, bankstown-lv2
-, triforce-lv2
+{
+  stdenv,
+  lib,
+  fetchFromGitHub,
+  lsp-plugins,
+  bankstown-lv2,
+  triforce-lv2,
 }:
 
 stdenv.mkDerivation rec {

--- a/apple-silicon-support/packages/linux-asahi/default.nix
+++ b/apple-silicon-support/packages/linux-asahi/default.nix
@@ -1,9 +1,10 @@
-{ lib
-, callPackage
-, writeText
-, linuxPackagesFor
-, withRust ? true
-, _kernelPatches ? [ ]
+{
+  lib,
+  callPackage,
+  writeText,
+  linuxPackagesFor,
+  withRust ? true,
+  _kernelPatches ? [ ],
 }:
 
 let
@@ -11,68 +12,110 @@ let
 
   # parse <OPT> [ymn]|foo style configuration as found in a patch's extraConfig
   # into a list of k, v tuples
-  parseExtraConfig = config:
+  parseExtraConfig =
+    config:
     let
-      lines =
-        builtins.filter (s: s != "") (lib.strings.splitString "\n" config);
-      parseLine = line: let
-        t = lib.strings.splitString " " line;
-        join = l: builtins.foldl' (a: b: "${a} ${b}")
-          (builtins.head l) (builtins.tail l);
-        v = if (builtins.length t) > 2 then join (builtins.tail t) else (i t 1);
-      in [ "CONFIG_${i t 0}" v ];
-    in map parseLine lines;
+      lines = builtins.filter (s: s != "") (lib.strings.splitString "\n" config);
+      parseLine =
+        line:
+        let
+          t = lib.strings.splitString " " line;
+          join = l: builtins.foldl' (a: b: "${a} ${b}") (builtins.head l) (builtins.tail l);
+          v = if (builtins.length t) > 2 then join (builtins.tail t) else (i t 1);
+        in
+        [
+          "CONFIG_${i t 0}"
+          v
+        ];
+    in
+    map parseLine lines;
 
   # parse <OPT>=lib.kernel.(yes|module|no)|lib.kernel.freeform "foo"
   # style configuration as found in a patch's extraStructuredConfig into
   # a list of k, v tuples
-  parseExtraStructuredConfig = config: lib.attrsets.mapAttrsToList
-    (k: v: [ "CONFIG_${k}" (v.tristate or v.freeform) ] ) config;
+  parseExtraStructuredConfig =
+    config:
+    lib.attrsets.mapAttrsToList (k: v: [
+      "CONFIG_${k}"
+      (v.tristate or v.freeform)
+    ]) config;
 
-  parsePatchConfig = { extraConfig ? "", extraStructuredConfig ? {}, ... }:
-    (parseExtraConfig extraConfig) ++
-    (parseExtraStructuredConfig extraStructuredConfig);
+  parsePatchConfig =
+    {
+      extraConfig ? "",
+      extraStructuredConfig ? { },
+      ...
+    }:
+    (parseExtraConfig extraConfig) ++ (parseExtraStructuredConfig extraStructuredConfig);
 
   # parse CONFIG_<OPT>=[ymn]|"foo" style configuration as found in a config file
   # into a list of k, v tuples
-  parseConfig = config:
+  parseConfig =
+    config:
     let
       parseLine = builtins.match ''(CONFIG_[[:upper:][:digit:]_]+)=(([ymn])|"([^"]*)")'';
       # get either the [ymn] option or the "foo" option; whichever matched
-      t = l: let v = (i l 2); in [ (i l 0) (if v != null then v else (i l 3)) ];
+      t =
+        l:
+        let
+          v = (i l 2);
+        in
+        [
+          (i l 0)
+          (if v != null then v else (i l 3))
+        ];
       lines = lib.strings.splitString "\n" config;
-    in map t (builtins.filter (l: l != null) (map parseLine lines));
+    in
+    map t (builtins.filter (l: l != null) (map parseLine lines));
 
   origConfigfile = ./config;
 
-  linux-asahi-pkg = { stdenv, lib, fetchFromGitHub, fetchpatch, linuxKernel,
-      rustc, rust-bindgen, ... } @ args:
+  linux-asahi-pkg =
+    {
+      stdenv,
+      lib,
+      fetchFromGitHub,
+      fetchpatch,
+      linuxKernel,
+      rustc,
+      rust-bindgen,
+      ...
+    }@args:
     let
       origConfigText = builtins.readFile origConfigfile;
 
       # extraConfig from all patches in order
       extraConfig =
-        lib.fold (patch: ex: ex ++ (parsePatchConfig patch)) [] _kernelPatches
-        ++ (lib.optional withRust [ "CONFIG_RUST" "y" ]);
+        lib.fold (patch: ex: ex ++ (parsePatchConfig patch)) [ ] _kernelPatches
+        ++ (lib.optional withRust [
+          "CONFIG_RUST"
+          "y"
+        ]);
       # config file text for above
-      extraConfigText = let
-        text = k: v: if (v == "y") || (v == "m") || (v == "n")
-          then "${k}=${v}" else ''${k}="${v}"'';
-      in (map (t: text (i t 0) (i t 1)) extraConfig);
+      extraConfigText =
+        let
+          text = k: v: if (v == "y") || (v == "m") || (v == "n") then "${k}=${v}" else ''${k}="${v}"'';
+        in
+        (map (t: text (i t 0) (i t 1)) extraConfig);
 
       # final config as a text file path
-      configfile = if extraConfig == [] then origConfigfile else
-        writeText "config" ''
-          ${origConfigText}
+      configfile =
+        if extraConfig == [ ] then
+          origConfigfile
+        else
+          writeText "config" ''
+            ${origConfigText}
 
-          # Patches
-          ${lib.strings.concatStringsSep "\n" extraConfigText}
-        '';
+            # Patches
+            ${lib.strings.concatStringsSep "\n" extraConfigText}
+          '';
       # final config as an attrset
-      configAttrs = let
-        makePair = t: lib.nameValuePair (i t 0) (i t 1);
-        configList = (parseConfig origConfigText) ++ extraConfig;
-      in builtins.listToAttrs (map makePair (lib.lists.reverseList configList));
+      configAttrs =
+        let
+          makePair = t: lib.nameValuePair (i t 0) (i t 1);
+          configList = (parseConfig origConfigText) ++ extraConfig;
+        in
+        builtins.listToAttrs (map makePair (lib.lists.reverseList configList));
 
       # used to fix issues when nixpkgs gets ahead of the kernel
       rustAtLeast = version: withRust && (lib.versionAtLeast rustc.version version);
@@ -101,4 +144,5 @@ let
     };
 
   linux-asahi = (callPackage linux-asahi-pkg { });
-in lib.recurseIntoAttrs (linuxPackagesFor linux-asahi)
+in
+lib.recurseIntoAttrs (linuxPackagesFor linux-asahi)

--- a/apple-silicon-support/packages/m1n1/default.nix
+++ b/apple-silicon-support/packages/m1n1/default.nix
@@ -1,21 +1,24 @@
-{ stdenv
-, buildPackages
-, lib
-, fetchFromGitHub
-, python3
-, dtc
-, imagemagick
-, isRelease ? false
-, withTools ? true
-, withChainloading ? false
-, customLogo ? null
+{
+  stdenv,
+  buildPackages,
+  lib,
+  fetchFromGitHub,
+  python3,
+  dtc,
+  imagemagick,
+  isRelease ? false,
+  withTools ? true,
+  withChainloading ? false,
+  customLogo ? null,
 }:
 
 let
-  pyenv = python3.withPackages (p: with p; [
-    construct
-    pyserial
-  ]);
+  pyenv = python3.withPackages (
+    p: with p; [
+      construct
+      pyserial
+    ]
+  );
 
   stdenvOpts = {
     targetPlatform.system = "aarch64-none-elf";
@@ -25,14 +28,17 @@ let
   rust = buildPackages.rust.override {
     stdenv = lib.recursiveUpdate buildPackages.stdenv stdenvOpts;
   };
-  rustPackages = rust.packages.stable.overrideScope (f: p: {
-    rustc-unwrapped = p.rustc-unwrapped.override {
-      stdenv = lib.recursiveUpdate p.rustc-unwrapped.stdenv stdenvOpts;
-    };
-  });
+  rustPackages = rust.packages.stable.overrideScope (
+    f: p: {
+      rustc-unwrapped = p.rustc-unwrapped.override {
+        stdenv = lib.recursiveUpdate p.rustc-unwrapped.stdenv stdenvOpts;
+      };
+    }
+  );
   rustPlatform = buildPackages.makeRustPlatform rustPackages;
 
-in stdenv.mkDerivation rec {
+in
+stdenv.mkDerivation rec {
   pname = "m1n1";
   version = "1.4.21";
 
@@ -46,13 +52,20 @@ in stdenv.mkDerivation rec {
   };
   cargoVendorDir = ".";
 
-  makeFlags = [ "ARCH=${stdenv.cc.targetPrefix}" ]
+  makeFlags =
+    [ "ARCH=${stdenv.cc.targetPrefix}" ]
     ++ lib.optional isRelease "RELEASE=1"
     ++ lib.optional withChainloading "CHAINLOADING=1";
 
-  nativeBuildInputs = [
-    dtc
-  ] ++ lib.optionals withChainloading [rustPackages.rustc rustPackages.cargo rustPlatform.cargoSetupHook]
+  nativeBuildInputs =
+    [
+      dtc
+    ]
+    ++ lib.optionals withChainloading [
+      rustPackages.rustc
+      rustPackages.cargo
+      rustPlatform.cargoSetupHook
+    ]
     ++ lib.optional (customLogo != null) imagemagick;
 
   postPatch = ''
@@ -76,35 +89,38 @@ in stdenv.mkDerivation rec {
     popd &>/dev/null
   '';
 
-  installPhase = ''
-    runHook preInstall
+  installPhase =
+    ''
+      runHook preInstall
 
-    mkdir -p $out/build
-    cp build/m1n1.bin $out/build
-  '' + (lib.optionalString withTools ''
-    mkdir -p $out/{bin,script,toolchain-bin}
-    cp -r proxyclient $out/script
-    cp -r tools $out/script
+      mkdir -p $out/build
+      cp build/m1n1.bin $out/build
+    ''
+    + (lib.optionalString withTools ''
+          mkdir -p $out/{bin,script,toolchain-bin}
+          cp -r proxyclient $out/script
+          cp -r tools $out/script
 
-    for toolpath in $out/script/proxyclient/tools/*.py; do
-      tool=$(basename $toolpath .py)
-      script=$out/bin/m1n1-$tool
-      cat > $script <<EOF
-#!/bin/sh
-${pyenv}/bin/python $toolpath "\$@"
-EOF
-      chmod +x $script
-    done
+          for toolpath in $out/script/proxyclient/tools/*.py; do
+            tool=$(basename $toolpath .py)
+            script=$out/bin/m1n1-$tool
+            cat > $script <<EOF
+      #!/bin/sh
+      ${pyenv}/bin/python $toolpath "\$@"
+      EOF
+            chmod +x $script
+          done
 
-    GCC=${buildPackages.gcc}
-    BINUTILS=${buildPackages.binutils-unwrapped}
+          GCC=${buildPackages.gcc}
+          BINUTILS=${buildPackages.binutils-unwrapped}
 
-    ln -s $GCC/bin/${stdenv.cc.targetPrefix}gcc $out/toolchain-bin/
-    ln -s $GCC/bin/${stdenv.cc.targetPrefix}ld $out/toolchain-bin/
-    ln -s $BINUTILS/bin/${stdenv.cc.targetPrefix}objcopy $out/toolchain-bin/
-    ln -s $BINUTILS/bin/${stdenv.cc.targetPrefix}objdump $out/toolchain-bin/
-    ln -s $GCC/bin/${stdenv.cc.targetPrefix}nm $out/toolchain-bin/
-  '') + ''
-    runHook postInstall
-  '';
+          ln -s $GCC/bin/${stdenv.cc.targetPrefix}gcc $out/toolchain-bin/
+          ln -s $GCC/bin/${stdenv.cc.targetPrefix}ld $out/toolchain-bin/
+          ln -s $BINUTILS/bin/${stdenv.cc.targetPrefix}objcopy $out/toolchain-bin/
+          ln -s $BINUTILS/bin/${stdenv.cc.targetPrefix}objdump $out/toolchain-bin/
+          ln -s $GCC/bin/${stdenv.cc.targetPrefix}nm $out/toolchain-bin/
+    '')
+    + ''
+      runHook postInstall
+    '';
 }

--- a/apple-silicon-support/packages/mesa-asahi-edge/default.nix
+++ b/apple-silicon-support/packages/mesa-asahi-edge/default.nix
@@ -1,48 +1,60 @@
-{ lib
-, fetchFromGitLab
-, mesa
+{
+  lib,
+  fetchFromGitLab,
+  mesa,
 }:
 
 (mesa.override {
-  galliumDrivers = [ "softpipe" "llvmpipe" "asahi" ];
-  vulkanDrivers = [ "swrast" "asahi" ];
-}).overrideAttrs (oldAttrs: {
-  version = "25.1.0-asahi";
-  src = fetchFromGitLab {
-    # tracking: https://pagure.io/fedora-asahi/mesa/commits/asahi
-    domain = "gitlab.freedesktop.org";
-    owner = "asahi";
-    repo = "mesa";
-    tag = "asahi-20250425";
-    hash = "sha256-3c3uewzKv5wL9BRwaVL4E3FnyA04veQwAPxfHiL7wII=";
-  };
+  galliumDrivers = [
+    "softpipe"
+    "llvmpipe"
+    "asahi"
+  ];
+  vulkanDrivers = [
+    "swrast"
+    "asahi"
+  ];
+}).overrideAttrs
+  (oldAttrs: {
+    version = "25.1.0-asahi";
+    src = fetchFromGitLab {
+      # tracking: https://pagure.io/fedora-asahi/mesa/commits/asahi
+      domain = "gitlab.freedesktop.org";
+      owner = "asahi";
+      repo = "mesa";
+      tag = "asahi-20250425";
+      hash = "sha256-3c3uewzKv5wL9BRwaVL4E3FnyA04veQwAPxfHiL7wII=";
+    };
 
-  mesonFlags =
-    let
-      badFlags = [
-        "-Dinstall-mesa-clc"
-        "-Dgallium-nine"
-        "-Dtools"
+    mesonFlags =
+      let
+        badFlags = [
+          "-Dinstall-mesa-clc"
+          "-Dgallium-nine"
+          "-Dtools"
+        ];
+        isBadFlagList = f: builtins.map (b: lib.hasPrefix b f) badFlags;
+        isGoodFlag = f: !(builtins.foldl' (x: y: x || y) false (isBadFlagList f));
+      in
+      (builtins.filter isGoodFlag oldAttrs.mesonFlags)
+      ++ [
+        # we do not build any graphics drivers these features can be enabled for
+        "-Dgallium-va=disabled"
+        "-Dgallium-vdpau=disabled"
+        "-Dgallium-xa=disabled"
+        "-Dtools=asahi"
       ];
-      isBadFlagList = f: builtins.map (b: lib.hasPrefix b f) badFlags;
-      isGoodFlag = f: !(builtins.foldl' (x: y: x || y) false (isBadFlagList f));
-    in
-    (builtins.filter isGoodFlag oldAttrs.mesonFlags) ++ [
-      # we do not build any graphics drivers these features can be enabled for
-      "-Dgallium-va=disabled"
-      "-Dgallium-vdpau=disabled"
-      "-Dgallium-xa=disabled"
-      "-Dtools=asahi"
+
+    # replace patches with ones tweaked slightly to apply to this version
+    patches = [
+      ./opencl.patch
     ];
 
-  # replace patches with ones tweaked slightly to apply to this version
-  patches = [
-    ./opencl.patch
-  ];
-
-  postInstall = (oldAttrs.postInstall or "") + ''
-    # we don't build anything to go in this output but it needs to exist
-    touch $spirv2dxil
-    touch $cross_tools
-  '';
-})
+    postInstall =
+      (oldAttrs.postInstall or "")
+      + ''
+        # we don't build anything to go in this output but it needs to exist
+        touch $spirv2dxil
+        touch $cross_tools
+      '';
+  })

--- a/apple-silicon-support/packages/uboot-asahi/default.nix
+++ b/apple-silicon-support/packages/uboot-asahi/default.nix
@@ -1,7 +1,8 @@
-{ lib
-, fetchFromGitHub
-, buildUBoot
-, m1n1
+{
+  lib,
+  fetchFromGitHub,
+  buildUBoot,
+  m1n1,
 }:
 
 (buildUBoot rec {
@@ -28,17 +29,18 @@
     CONFIG_VIDEO_FONT_16X32=y
     CONFIG_CMD_BOOTMENU=y
   '';
-}).overrideAttrs (o: {
-  # nixos's downstream patches are not applicable
-  patches = [ 
-  ];
+}).overrideAttrs
+  (o: {
+    # nixos's downstream patches are not applicable
+    patches = [
+    ];
 
-  # DTC= flag somehow breaks DTC compilation so we remove it
-  makeFlags = builtins.filter (s: (!(lib.strings.hasPrefix "DTC=" s))) o.makeFlags;
+    # DTC= flag somehow breaks DTC compilation so we remove it
+    makeFlags = builtins.filter (s: (!(lib.strings.hasPrefix "DTC=" s))) o.makeFlags;
 
-  preInstall = ''
-    # compress so that m1n1 knows U-Boot's size and can find things after it
-    gzip -n u-boot-nodtb.bin
-    cat ${m1n1}/build/m1n1.bin arch/arm/dts/t[68]*.dtb u-boot-nodtb.bin.gz > m1n1-u-boot.bin
-  '';
-})
+    preInstall = ''
+      # compress so that m1n1 knows U-Boot's size and can find things after it
+      gzip -n u-boot-nodtb.bin
+      cat ${m1n1}/build/m1n1.bin arch/arm/dts/t[68]*.dtb u-boot-nodtb.bin.gz > m1n1-u-boot.bin
+    '';
+  })

--- a/default.nix
+++ b/default.nix
@@ -1,15 +1,25 @@
 # This file provides backward compatibility to nix < 2.4 clients
-{ system ? builtins.currentSystem }:
+{
+  system ? builtins.currentSystem,
+}:
 let
   lock = builtins.fromJSON (builtins.readFile ./flake.lock);
 
-  inherit (lock.nodes.flake-compat.locked) owner repo rev narHash;
+  inherit (lock.nodes.flake-compat.locked)
+    owner
+    repo
+    rev
+    narHash
+    ;
 
   flake-compat = fetchTarball {
     url = "https://github.com/${owner}/${repo}/archive/${rev}.tar.gz";
     sha256 = narHash;
   };
 
-  flake = import flake-compat { inherit system; src = ./.; };
+  flake = import flake-compat {
+    inherit system;
+    src = ./.;
+  };
 in
 flake.defaultNix

--- a/flake.lock
+++ b/flake.lock
@@ -34,7 +34,28 @@
     "root": {
       "inputs": {
         "flake-compat": "flake-compat",
-        "nixpkgs": "nixpkgs"
+        "nixpkgs": "nixpkgs",
+        "treefmt-nix": "treefmt-nix"
+      }
+    },
+    "treefmt-nix": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1753006367,
+        "narHash": "sha256-tzbhc4XttkyEhswByk5R38l+ztN9UDbnj0cTcP6Hp9A=",
+        "owner": "numtide",
+        "repo": "treefmt-nix",
+        "rev": "421b56313c65a0815a52b424777f55acf0b56ddf",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "treefmt-nix",
+        "type": "github"
       }
     }
   },

--- a/iso-configuration/default.nix
+++ b/iso-configuration/default.nix
@@ -1,5 +1,10 @@
 # configuration that is specific to the ISO
-{ config, pkgs, lib, ... }:
+{
+  config,
+  pkgs,
+  lib,
+  ...
+}:
 {
   imports = [
     ./installer-configuration.nix


### PR DESCRIPTION
Since this is under the `nix-community` banner, this project should decide on a formatter. This PR currently chooses `nixfmt-rfc-style` via `github:numtide/treefmt-nix` flake, formats all files, and adds a `.git-blame-ignore-revs` file to ignore this mass reformat when blaming.

This would also allow for pre-commit hooks for formatting all files as well as automatic merge checks when opening additional PRs which reduces the chance of merge conflicts occurring.