### PR TITLE
asahi-fwextract: switch to new nixpkgs semantics

### DIFF
--- a/apple-silicon-support/packages/asahi-fwextract/default.nix
+++ b/apple-silicon-support/packages/asahi-fwextract/default.nix
@@ -1,14 +1,17 @@
-{ lib
-, python3
-, fetchFromGitHub
-, gzip
-, gnutar
-, lzfse
+{
+  python3,
+  fetchFromGitHub,
+  gzip,
+  gnutar,
+  lzfse,
 }:
 
 python3.pkgs.buildPythonApplication rec {
   pname = "asahi-fwextract";
   version = "0.7.8";
+  pyproject = true;
+
+  build-system = [ python3.pkgs.setuptools ];
 
   # tracking version: https://packages.fedoraproject.org/pkgs/asahi-installer/python3-asahi_firmware/
   src = fetchFromGitHub {
@@ -25,8 +28,6 @@ python3.pkgs.buildPythonApplication rec {
       --replace '"tar"' '"${gnutar}/bin/tar"' \
       --replace '"xf"' '"-x", "-I", "${gzip}/bin/gzip", "-f"'
   '';
-
-  nativeBuildInputs = [ python3.pkgs.setuptools ];
 
   doCheck = false;
 }


### PR DESCRIPTION
Set pyproject = true, and add setuptools to build-system.