### PR TITLE
flake: expose `linux-asahi` properly

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -37,8 +37,10 @@
               ];
             };
           in {
-            inherit (pkgs) m1n1 uboot-asahi linux-asahi asahi-fwextract mesa-asahi-edge;
+            inherit (pkgs) m1n1 uboot-asahi asahi-fwextract mesa-asahi-edge;
             inherit (pkgs) asahi-audio;
+
+            linux-asahi = pkgs.linux-asahi.kernel;
 
             installer-bootstrap =
               let


### PR DESCRIPTION
This commit allows for `nix flake check` `nix flake show` to pass.

Fixes issue #321.

## Testing
Ensure that `nix flake check` and `nix flake show` are able to display all attributes correctly.


``` shellsession
$ nix flake show --all-systems
├───nixosModules
│   ├───apple-silicon-support: NixOS module
│   └───default: NixOS module
├───overlays
│   ├───apple-silicon-overlay: Nixpkgs overlay
│   └───default: Nixpkgs overlay
└───packages
    ├───aarch64-linux
    │   ├───asahi-audio: package 'asahi-audio-3.3'
    │   ├───asahi-fwextract: package 'asahi-fwextract-0.7.8'
    │   ├───installer-bootstrap: package 'nixos-25.11.20250528.96ec055-aarch64-linux.iso'
    │   ├───linux-asahi: package 'linux-6.14.8-asahi'
    │   ├───m1n1: package 'm1n1-1.4.21'
    │   ├───mesa-asahi-edge: package 'mesa-25.1.0-asahi'
    │   └───uboot-asahi: package 'uboot-apple_m1_defconfig-2025.04-1-asahi'
    └───x86_64-linux
        ├───asahi-audio: package 'asahi-audio-aarch64-unknown-linux-gnu-3.3'
        ├───asahi-fwextract: package 'asahi-fwextract-0.7.8-aarch64-unknown-linux-gnu'
        ├───installer-bootstrap: package 'nixos-25.11.20250528.96ec055-aarch64-linux.iso-aarch64-unknown-linux-gnu'
        ├───linux-asahi: package 'linux-aarch64-unknown-linux-gnu-6.14.8-asahi'
        ├───m1n1: package 'm1n1-aarch64-unknown-linux-gnu-1.4.21'
        ├───mesa-asahi-edge: package 'mesa-aarch64-unknown-linux-gnu-25.1.0-asahi'
        └───uboot-asahi: package 'uboot-apple_m1_defconfig-aarch64-unknown-linux-gnu-2025.04-1-asahi'
```