### PR TITLE
release 2025-08-23

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Please see the documentation and guide below to get started.
 ## Documentation
 
 * [Release Notes](docs/release-notes.md)
-* [Setup, Installation, and Maintenance Guide (2025-08-10)](docs/uefi-standalone.md)
+* [Setup, Installation, and Maintenance Guide (2025-08-23)](docs/uefi-standalone.md)
 
 ## Credits
 

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -2,9 +2,10 @@
 
 This file contains important information for each release.
 
-## 2025-xx-yy
+## 2025-08-23
 
-This release drops our custom Mesa override.
+This release drops our custom Mesa override, which fixes a build issue with
+recent nixpkgs.
 
 Since mesa 25.1, support for asahi is enabled by default.
 This means, the nixpkgs mesa is sufficient and we don't need any custom mesa,
@@ -14,6 +15,9 @@ In addition to the now ineffective
 `hardware.asahi.useExperimentalGPUDriver` option, this also removes the
 `hardware.asahi.experimentalGPUInstallMode` option, which was already
 deprecated before.
+
+This release also updates nixpkgs and corrects another issue building the kernel
+with Rust support. Thanks to dramforever and K900 for the fix.
 
 ## 2025-08-10
 

--- a/docs/uefi-standalone.md
+++ b/docs/uefi-standalone.md
@@ -1,10 +1,10 @@
-# UEFI Boot Standalone NixOS (2025-08-10)
+# UEFI Boot Standalone NixOS (2025-08-23)
 
 This guide will build and was tested with the following software:
 * Asahi Linux kernel version asahi-6.14.8-1
 * m1n1 version v1.4.21
 * Asahi Linux's U-Boot version 2025.04-1-asahi
-* Nixpkgs, as of 2025-08-06
+* Nixpkgs, as of 2025-08-19
 * macOS stub 13.5
 
 NOTE: The latest version of this guide will always be [at its home](https://github.com/nix-community/nixos-apple-silicon/blob/main/docs/uefi-standalone.md). For more general information about Linux on Apple Silicon Macs, refer to the [Asahi Linux project](https://asahilinux.org/) and [alpha installer release](https://asahilinux.org/2022/03/asahi-linux-alpha-release/).

--- a/flake.lock
+++ b/flake.lock
@@ -17,11 +17,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1754725699,
-        "narHash": "sha256-iAcj9T/Y+3DBy2J0N+yF9XQQQ8IEb5swLFzs23CdP88=",
+        "lastModified": 1755615617,
+        "narHash": "sha256-HMwfAJBdrr8wXAkbGhtcby1zGFvs+StOp19xNsbqdOg=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "85dbfc7aaf52ecb755f87e577ddbe6dbbdbc1054",
+        "rev": "20075955deac2583bb12f07151c2df830ef346b4",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
A bit embarrassed that the last release was broken. This fixes it. Also updates nixpkgs to lock in some fixes there.

Tested on 2020 Macbook Pro 15" M1 Max that it builds, boots, and installs. Using a Plasma 6 desktop environment. Functioning graphics and sound. I haven't identified any issues.