### PR TITLE
Expose a nixbot output

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -24,6 +24,11 @@
         formatting = outputs.formatter.${system};
       });
 
+      nixbot = forAllSystems (system: {
+        inherit (outputs.checks."${system}") formatting;
+        inherit (outputs.packages."${system}") linux-asahi uboot-asahi installer-bootstrap;
+      });
+
       devShells = forAllSystems (system: {
         default = inputs.nixpkgs.legacyPackages.${system}.mkShellNoCC {
           packages = [ outputs.formatter.${system} ];

--- a/nixbot.toml
+++ b/nixbot.toml
@@ -1,0 +1,1 @@
+attribute = "nixbot"


### PR DESCRIPTION
nixbot has been building `checks` only so far, but we can give it another attribute to evaluate. Give it something that also builds the installer, so reviewing nixpkgs updates becomes less manual (to ensure our installer still builds).