### PR TITLE
uboot-asahi: 2026.04-2-asahi -> 2026.07-2-asahi

### DIFF
--- a/apple-silicon-support/packages/uboot-asahi/default.nix
+++ b/apple-silicon-support/packages/uboot-asahi/default.nix
@@ -9,10 +9,10 @@
   src = fetchFromGitHub {
     owner = "AsahiLinux";
     repo = "u-boot";
-    rev = "asahi-v2026.04-2";
-    hash = "sha256-DbXS8L3j5w8ryYknR+DnAonAdPMNNLaBwWyc27vK0r4=";
+    rev = "asahi-v2026.07-1";
+    hash = "sha256-Qdlun2aB9/ll3yPhOgXx+3fo8aR+4efuhn60ihEij+g=";
   };
-  version = "2026.04-2-asahi";
+  version = "2026.07-1-asahi";
 
   defconfig = "apple_m1_defconfig";
   extraMeta.platforms = [ "aarch64-linux" ];

--- a/apple-silicon-support/packages/uboot-asahi/default.nix
+++ b/apple-silicon-support/packages/uboot-asahi/default.nix
@@ -9,10 +9,10 @@
   src = fetchFromGitHub {
     owner = "AsahiLinux";
     repo = "u-boot";
-    rev = "asahi-v2026.07-1";
-    hash = "sha256-Qdlun2aB9/ll3yPhOgXx+3fo8aR+4efuhn60ihEij+g=";
+    rev = "asahi-v2026.07-2";
+    hash = "sha256-9E79VceZcPw55zj6BBwgIBP/2OrHRS/w3ypGyOWfE6U=";
   };
-  version = "2026.07-1-asahi";
+  version = "2026.07-2-asahi";
 
   defconfig = "apple_m1_defconfig";
   extraMeta.platforms = [ "aarch64-linux" ];


### PR DESCRIPTION
Fixes M3 usb support. Compiles and boots on my t8112-j493 and will test on my t6020-j414c later when I get a usb.