### PR TITLE
modules/video: add avd support module

### DIFF
--- a/apple-silicon-support/modules/default.nix
+++ b/apple-silicon-support/modules/default.nix
@@ -15,6 +15,7 @@ in
     ./peripheral-firmware
     ./boot-m1n1
     ./sound
+    ./video
   ];
 
   config = lib.mkIf cfg.enable {

--- a/apple-silicon-support/modules/video/default.nix
+++ b/apple-silicon-support/modules/video/default.nix
@@ -13,6 +13,17 @@ in
     hardware.firmware = [
       pkgs.avd-fw
     ];
+
+    hardware.graphics = lib.mkIf (cfg.avd.vaapi-support) {
+      enable = true;
+      extraPackages = [
+        pkgs.libva-v4l2_request-sofus13
+      ];
+    };
+
+    environment.sessionVariables = lib.mkIf (cfg.avd.vaapi-support) {
+      LIBVA_DRIVER_NAME = "v4l2_request-sofus13";
+    };
   };
 
   options.hardware.asahi.avd = {
@@ -21,6 +32,13 @@ in
       default = config.hardware.asahi.enable;
       description = ''
         Setup the firmware required for the Apple Video Decoder to work properly.
+      '';
+    };
+    vaapi-support = lib.mkOption {
+      type = lib.types.bool;
+      default = false;
+      description = ''
+        Use libva-v4l2_request-sofus13 to expose a vaapi interface with AVD (Experimental)
       '';
     };
   };

--- a/apple-silicon-support/modules/video/default.nix
+++ b/apple-silicon-support/modules/video/default.nix
@@ -1,0 +1,27 @@
+{
+  config,
+  pkgs,
+  lib,
+  ...
+}:
+
+let
+  cfg = config.hardware.asahi;
+in
+{
+  config = lib.mkIf (cfg.enable && cfg.avd.enable) {
+    hardware.firmware = [
+      pkgs.avd-fw
+    ];
+  };
+
+  options.hardware.asahi.avd = {
+    enable = lib.mkOption {
+      type = lib.types.bool;
+      default = config.hardware.asahi.enable;
+      description = ''
+        Setup the firmware required for the Apple Video Decoder to work properly.
+      '';
+    };
+  };
+}

--- a/apple-silicon-support/packages/libva-v4l2_request-sofus13/default.nix
+++ b/apple-silicon-support/packages/libva-v4l2_request-sofus13/default.nix
@@ -1,0 +1,55 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  meson,
+  ninja,
+  pkg-config,
+  libva,
+  libdrm,
+  linuxHeaders,
+}:
+stdenv.mkDerivation (finalAttrs: {
+  pname = "libva-v4l2_request-sofus13";
+  version = "1.3";
+
+  src = fetchFromGitHub {
+    owner = "sofus13";
+    repo = "libva-v4l2_request";
+    tag = finalAttrs.version;
+    hash = "sha256-qN/IEte/kFd2Zi9DSPTYSehCkE3MenV9a8n0LBXuICQ=";
+  };
+
+  nativeBuildInputs = [
+    meson
+    ninja
+    pkg-config
+  ];
+
+  buildInputs = [
+    libva
+    libdrm
+    linuxHeaders
+  ];
+
+  mesonFlags = [
+    "-Ddriverdir=${placeholder "out"}/lib/dri"
+  ];
+
+  postInstall = ''
+    mv $out/lib/dri/v4l2_request{,-sofus13}_drv_video.so
+  '';
+
+  meta = {
+    description = "VA-API (libva) backend driver for V4L2 stateless video decoders using the Media Request API";
+    longDescription = ''
+      A fork of the upstream https://xff.cz/git/libva-v4l2_request/ with a few fixes that were noticed with AVD. It itself is a fork of https://github.com/bootlin/libva-v4l2-request.
+
+      When support is available in the kernel and hardware, this allows hardware decoding of MPEG-2, H.264, HEVC, VP8, VP9 and AV1 through VA-API. AVD has support for all of these apart from VP8 and MPEG-2, though AV-1 is only supported on M3+.
+    '';
+    homepage = "https://github.com/sofus13/libva-v4l2_request";
+    license = lib.licenses.gpl3Plus;
+    maintainers = [ lib.maintainers.sempiternal-aurora ];
+    platforms = lib.platforms.linux;
+  };
+})

--- a/apple-silicon-support/packages/overlay.nix
+++ b/apple-silicon-support/packages/overlay.nix
@@ -1,4 +1,5 @@
 final: prev: {
+  libva-v4l2_request-sofus13 = final.callPackage ./libva-v4l2_request-sofus13 { };
   linux-asahi = final.callPackage ./linux-asahi { };
   uboot-asahi = final.callPackage ./uboot-asahi { };
   mesa =

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -2,6 +2,20 @@
 
 This file contains important information for each release.
 
+## YYYY-MM-DD (unreleased)
+
+Support for the Apple Video Decoder (AVD) has been added, and is enabled by
+`hardware.asahi.avd.enable` (`true` by default). Currently, the kernel
+driver/firmware only supports the Video 4 Linux 2 (V4L2) Requests api, which
+isn't supported by a lot of media engines (gstreamer has basic support,
+ffmpeg/mpv requires patches).
+
+To combat this, there is a wrapper driver for `v4l2_requests` that exposes a
+VA-API interface, for which support is much more common. This is packaged here
+in `libva-v4l2_requests-sofus13`, and can be enabled with
+`hardware.asahi.avd.vaapi-support`, which is false by default for various
+stability reasons.
+
 ## 2026-07-30
 
 Among other kernel updates, the kernel update to 6.18.x included a remame

--- a/flake.nix
+++ b/flake.nix
@@ -59,7 +59,7 @@
         in
         {
           linux-asahi = pkgs.linux-asahi.kernel;
-          uboot-asahi = pkgs.uboot-asahi;
+          inherit (pkgs) uboot-asahi libva-v4l2_request-sofus13;
 
           installer-bootstrap =
             let


### PR DESCRIPTION
Add an option under `hardware.asahi.avd` to setup the Apple Video Decoder for use, as well as an option to use `libva-v4l2_request` to provide a vaapi wrapper for the hardware module. I have tested, and the nixpkgs bump doesn't seem to have the python3Packages.dbus-python cross compilation problems. I built it cross compiling on the latest nixpkgs, and I am currently manually built the `installer-bootstrap` on my framework, no errors so far.

It also has built and works on my t8112-j413, however when using `mpv`, the command needs to be `mpv --hwdec=vaapi --vo=dmabuf-wayland <video file>` because of some problem with gpu-next? According to chadmed. Because of these problems, it is marked as experimental and disabled by default.