### PR TITLE
installer-bootstrap: include M3 Pro/Max usb module in initrd

### DIFF
--- a/apple-silicon-support/modules/kernel/default.nix
+++ b/apple-silicon-support/modules/kernel/default.nix
@@ -34,6 +34,7 @@
       "macsmc-reboot"
       "i2c-pasemi-platform"
       "tps6598x"
+      "sn201202x"
       "apple-dart"
       "dwc3"
       "dwc3-of-simple"


### PR DESCRIPTION
Adds the new sn201202x (ACE3) Driver to the initrd, the tps6598x based chip that exists on the SPMI bus.